### PR TITLE
Error fix

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -46,7 +46,7 @@ def get_smoothing_filter(FFT_window_size_ms, filter_length_ms, verbose = 0):
         print("Smoothing buffer contains %d FFT windows (sigma: %.3f) --> min_contribution: %.3f%%" %(buffer_length, filter_sigma, min_fraction))
         print("Filter weights:")
         for i, w in enumerate(filter_weights):
-            print("%02d: %.3f" %(len(filter_weights)-i, w))
+            print("%02d: %.3f" %(len(filter_weights)-i, w.item()))
 
     return filter_weights
 


### PR DESCRIPTION
 only 0-dimensional arrays can be converted to Python scalars Error at line 49 on utils.py